### PR TITLE
Fix typos

### DIFF
--- a/c_src/git.cpp
+++ b/c_src/git.cpp
@@ -271,7 +271,7 @@ static ERL_NIF_TERM fetch_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[
   if (git_remote_fetch(remote,
                        NULL,               // refspecs, NULL to use the configured ones
                        NULL,               // options, empty for defaults
-                       fetch_or_pull) < 0) // reflog mesage, "fetch" (or NULL) or "pull"
+                       fetch_or_pull) < 0) // reflog message, "fetch" (or NULL) or "pull"
     return make_git_error(env, "Failed to fetch from " + remote_name);
 
   return ATOM_OK;

--- a/src/egit.app.src
+++ b/src/egit.app.src
@@ -1,5 +1,5 @@
 {application,egit,
-             [{description,"Native git Erlang inteface library"},
+             [{description,"Native git Erlang interface library"},
               {vsn,"0.1.9"},
               {registered,[]},
               {modules,[git]},

--- a/src/git.erl
+++ b/src/git.erl
@@ -462,7 +462,7 @@ remote_set_url(Repo, Name, URL) ->
   remote_set_url(Repo, Name, URL, []).
 
 %% @doc Add a remote.
-%% If `Opts' contains `push', then the repository is pushed ot the remote `URL'.
+%% If `Opts' contains `push', then the repository is pushed to the remote `URL'.
 remote_set_url(Repo, Name, URL, Opts) ->
   remote_nif(Repo, {seturl, to_bin(URL)}, to_bin(Name), Opts).
 


### PR DESCRIPTION
Found via `codespell -S _build,./c_src/fmt -L te`