### PR TITLE
Use pkg-config for includes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "c_src/fmt"]
-	path = c_src/fmt
-	url = https://github.com/fmtlib/fmt.git
-  ignore = dirty

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -28,8 +28,9 @@ HAVE_FORMAT ?= $(C20_FEATURES)
 HAVE_SRCLOC ?= $(C20_FEATURES)
 
 CPPFLAGS += \
-  $(if $(findstring $(HAVE_FORMAT),1),-DHAVE_FORMAT,-DFMT_HEADER_ONLY -Ifmt/include -Wno-array-bounds -Wno-stringop-overflow) \
-  $(if $(findstring $(HAVE_SRCLOC),1),-DHAVE_SRCLOC)
+  $(if $(findstring $(HAVE_FORMAT),1),-DHAVE_FORMAT,-DFMT_HEADER_ONLY $(shell pkg-config --cflags fmt) -Wno-array-bounds -Wno-stringop-overflow) \
+  $(if $(findstring $(HAVE_SRCLOC),1),-DHAVE_SRCLOC) \
+  $(shell pkg-config --cflags libgit2)
 
 # System type and C compiler/flags.
 
@@ -42,7 +43,7 @@ endif
 CXXFLAGS   ?= -finline-functions -Wall -std=c++20
 
 CXXFLAGS   += $(OPTIMIZE) -fPIC $(ERL_CXXFLAGS)
-LDFLAGS    += $(ERL_LDFLAGS) -lei -lgit2 -shared
+LDFLAGS    += $(ERL_LDFLAGS) -lei $(shell pkg-config --libs libgit2) -shared
 
 UNAME_SYS  := $(shell uname -s)
 ifeq ($(UNAME_SYS),Darwin)
@@ -74,9 +75,4 @@ $(SO_OUTPUT): $(OBJECTS)
 	$(CXX) $(OBJECTS) $(LDFLAGS) -o $(SO_OUTPUT)
 
 %.o: %.cpp $(wildcard *.hpp)
-	@if [ -z $(findstring $(HAVE_FORMAT),1) ]; then \
-	  echo "==> Updating fmt submodule"; \
-		[ -z "$(shell git config --global safe.directory)" ] && git config --global --add safe.directory '*' || true; \
-		git submodule update --init --recursive; \
-	fi
 	$(COMPILE_CPP) $(OUTPUT_OPTION) $<


### PR DESCRIPTION
@saleyn This makes the build work for me, both via make and mix compile (although I have not tested the binary yet)
I assume pkg-config should work on any system where libraries are installed globally, in my case Homebrew.

Please take a look if this makes sense to you.